### PR TITLE
Update app.js

### DIFF
--- a/TodoListSPA/app.js
+++ b/TodoListSPA/app.js
@@ -3,11 +3,12 @@
 config.callback = loggedin;
 var authenticationContext = new AuthenticationContext(config);
 
+if (authenticationContext.isCallback(window.location.hash)) {
+    authenticationContext.handleWindowCallback();
+}
+
 if (!config.popUp) {
-    if (authenticationContext.isCallback(window.location.hash)) {
-        authenticationContext.handleWindowCallback();
-    }
-    else {
+    if (!authenticationContext.isCallback(window.location.hash)) {
         var user = authenticationContext.getCachedUser();
         if (user && window.parent === window && !window.opener) {
             // Display the user


### PR DESCRIPTION
If config.popUp is set to true, the call to authenticationContext.acquireToken will fail with an error message of "Token renewal operation failed due to timeout".

I moved the handleWindowCallback so that it is always called on redirect from AAD, rather than just when popup == false